### PR TITLE
Fix tests

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,7 @@ appraise "rails-3-2" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 3.2.22.2"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -13,6 +14,7 @@ appraise "rails-4-1" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.1.16"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -23,6 +25,7 @@ appraise "rails-4-2" do
     gem "mysql2", "~> 0.4.10", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.2.10"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
 end
 
 appraise "rails-5-0" do

--- a/Appraisals
+++ b/Appraisals
@@ -3,7 +3,7 @@ appraise "rails-3-2" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 3.2.22.2"
-  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -14,7 +14,7 @@ appraise "rails-4-1" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.1.16"
-  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -25,7 +25,7 @@ appraise "rails-4-2" do
     gem "mysql2", "~> 0.4.10", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.2.10"
-  gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 end
 
 appraise "rails-5-0" do

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 3.2.22.2"
 

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake", "~> 12.2.0", platforms: [:ruby_19]
+gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
 gem "appraisal"
 gem "activerecord", "~> 3.2.22.2"
 

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 3.2.22.2"
 

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -6,8 +6,6 @@ gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
 gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"
-gem "public_suffix", "~> 2.0.5", platforms: [:ruby_20]
-gem "jwt", "~> 1.5.6", platforms: [:ruby_20]
 
 group :development do
   gem "github_changelog_generator", "1.9.0"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"
 gem "public_suffix", "~> 2.0.5", platforms: [:ruby_20]

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -6,6 +6,8 @@ gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
 gem "rake"
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"
+gem "public_suffix", "~> 2.0.5", platforms: [:ruby_20]
+gem "jwt", "~> 1.5.6", platforms: [:ruby_20]
 
 group :development do
   gem "github_changelog_generator", "1.9.0"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 4.2.10"
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake", "~> 12.2.0", platforms: [:ruby_19]
+gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
 gem "appraisal"
 gem "activerecord", "~> 4.2.10"
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake", "~> 12.2.0", platforms: [:ruby_19, :ruby_20]
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 4.2.10"
 


### PR DESCRIPTION
Updating test cases to pin gem versions based on the ruby version.

### Ruby 2.0.0 required in rake as of 12.3.0

https://github.com/ruby/rake/commit/41359487ab66f18c85998c858b93f5713b5fd07e
https://github.com/ruby/rake/blob/master/History.rdoc#1230

### Ruby 2.1.x is required in public_suffix as of 3.0.0

https://github.com/weppos/publicsuffix-ruby/commit/c6560dce166c64d8e903d0c8b5d5435d721795ad
https://github.com/weppos/publicsuffix-ruby/blob/master/CHANGELOG.md#release-300
